### PR TITLE
Add alert target validation

### DIFF
--- a/ambariclient/base.py
+++ b/ambariclient/base.py
@@ -396,7 +396,11 @@ class Model(object):
     min_version = OLDEST_SUPPORTED_VERSION
 
     def __init__(self, parent, data=None):
-        self._data = data if data is not None else {}
+        if data is None:
+            data = {}
+
+        self._data = dict((key, value) for key, value in six.iteritems(data)
+                          if key in set(self.fields))
         self.parent = parent
         self.client = parent.client
         self._is_inflated = False

--- a/ambariclient/base.py
+++ b/ambariclient/base.py
@@ -23,6 +23,7 @@ import time
 from ambariclient import events, exceptions, utils
 
 LOG = logging.getLogger(__name__)
+LOG.addHandler(utils.NullHandler())
 
 OLDEST_SUPPORTED_VERSION = (1, 7, 0)
 

--- a/ambariclient/client.py
+++ b/ambariclient/client.py
@@ -20,6 +20,7 @@ from ambariclient import models, utils, base, exceptions
 from ambariclient.exceptions import handle_response
 
 LOG = logging.getLogger(__name__)
+LOG.addHandler(utils.NullHandler())
 
 # this defines where the Ambari client delegates to for actual logic
 ENTRY_POINTS = {

--- a/ambariclient/events.py
+++ b/ambariclient/events.py
@@ -14,7 +14,10 @@ from collections import namedtuple
 import logging
 import inspect
 
+from ambariclient.utils import NullHandler
+
 LOG = logging.getLogger(__name__)
+LOG.addHandler(NullHandler())
 
 EVENT_HANDLERS = {}
 state_list = ['ANY', 'STARTED', 'FAILED', 'FINISHED', 'PROGRESS']

--- a/ambariclient/models.py
+++ b/ambariclient/models.py
@@ -20,9 +20,10 @@ import os
 import time
 
 from ambariclient import base, exceptions, events
-from ambariclient.utils import normalize_underscore_case
+from ambariclient.utils import normalize_underscore_case, NullHandler
 
 LOG = logging.getLogger(__name__)
+LOG.addHandler(NullHandler())
 
 
 class Bootstrap(base.PollableMixin, base.GeneratedIdentifierMixin, base.QueryableModel):

--- a/ambariclient/models.py
+++ b/ambariclient/models.py
@@ -1049,3 +1049,18 @@ class AlertTarget(base.QueryableModel, base.GeneratedIdentifierMixin):
     data_key = 'AlertTarget'
     primary_key = 'id'
     fields = ('name', 'description', 'notification_type', 'global', 'properties', 'alert_states')
+
+    @events.evented
+    def create(self, validate=False, **kwargs):
+        """Create a new alert target.
+
+        :param validate: If `True`, test the target against the alerting backend before creating.
+            Will throw an exception if a test alert fails, e.g. the server is unable to connect to
+            the SMTP server for the `EMAIL` notification type.
+        :returns: A new instance of AlertTarget
+        """
+        if self.primary_key in kwargs:
+            del kwargs[self.primary_key]
+        data = self._generate_input_dict(**kwargs)
+        self.load(self.client.post(self.url, params={'validate_config': bool(validate)}, data=data))
+        return self

--- a/ambariclient/shell.py
+++ b/ambariclient/shell.py
@@ -25,6 +25,7 @@ from ambariclient import events, base, models, utils
 
 logging.basicConfig(level=logging.CRITICAL)
 LOG = logging.getLogger(__name__)
+LOG.addHandler(utils.NullHandler())
 
 
 def model_event(event, event_state, obj, **kwargs):

--- a/ambariclient/utils.py
+++ b/ambariclient/utils.py
@@ -12,6 +12,16 @@
 
 import re
 
+try:
+    from logging import NullHandler
+except ImportError:
+    from logging import Handler
+
+    class NullHandler(Handler):
+        def emit(self, record):
+            pass
+
+
 DEFAULT_PORTS = {
     'http': 80,
     'https': 443,


### PR DESCRIPTION
Add (optional) alert target validation using the `validate` keyword to `Ambari.alert_target.create`. So that backward compatibility is maintained, no validation is done by default.

For more information, see: https://github.com/apache/ambari/blob/trunk/ambari-server/docs/api/v1/alert-dispatching.md#validation