### PR TITLE
Add support for getting client config tar from service components

### DIFF
--- a/ambariclient/client.py
+++ b/ambariclient/client.py
@@ -12,8 +12,11 @@
 
 import copy
 import functools
+import io
 import json
 import logging
+import tarfile
+
 import requests
 
 from ambariclient import models, utils, base, exceptions
@@ -158,7 +161,11 @@ class HttpClient(object):
         # there is no consistent way to determine response type
         # so assume json if it's not an empty string
         if len(response.text) > 0:
-            if response.headers.get('content-type') != 'application/json':
+            if response.headers.get('content-type') == 'application/x-ustar':
+                tarstream = io.BytesIO(response.content)
+                tarstream.seek(0)
+                return tarfile.open(fileobj=tarstream)
+            elif response.headers.get('content-type') != 'application/json':
                 # Log bad methods so we can report them
                 LOG.debug("Wrong response content-type for %s %s: %s", method,
                           url, response.headers.get('content-type'))

--- a/ambariclient/models.py
+++ b/ambariclient/models.py
@@ -226,6 +226,13 @@ class Component(base.QueryableModel):
         return { 'name': self.component_name }
 
 
+class ClusterServiceComponentCollection(base.QueryableModelCollection):
+    def get_client_config_tar(self):
+        """Returns tarfile.Tarfile instance."""
+        url = self.url + "?format=client_config_tar"
+        return self.client.get(url)
+
+
 class HostComponentCollection(base.QueryableModelCollection):
     @property
     def _server_components(self):
@@ -389,6 +396,7 @@ class HostComponent(Component):
 
 
 class ClusterServiceComponent(Component):
+    collection_class = ClusterServiceComponentCollection
     fields = ['cluster_name', 'component_name', 'service_name', 'category',
               'installed_count', 'started_count', 'total_count']
     extra_fields = {


### PR DESCRIPTION
This commit adds a `get_client_config_tar()` method to a new `ClusterServiceComponentCollection` class and modifying `ambariclient.client.HttpClient` to handle the specifics of a tarstream request response. 

Example of code that exercises this new functionality in Python 3 is as follows:
```
>>> from ambariclient.client import Ambari
>>> ambari = Ambari('http://localhost:8080', username='admin', password='admin')
>>> client_config = ambari.clusters('cluster').services('HDFS').components.get_client_config_tar()
>>> client_config
<tarfile.TarFile object at 0x10e2bb8d0>
>>> client_config.getmembers()
[<TarInfo 'HDFS_CLIENT/.' at 0x10e25a9a8>, <TarInfo 'HDFS_CLIENT/hadoop-env.sh' at 0x10e25aa70>, <TarInfo 'HDFS_CLIENT/core-site.xml' at 0x10e25ab38>, <TarInfo 'HDFS_CLIENT/log4j.properties' at 0x10e25ac00>, <TarInfo 'HDFS_CLIENT/hdfs-site.xml' at 0x10e25acc8>]
```

I've also used the same code against Python 2.7, which works without a hitch.