### PR TITLE
Checking of 'content-type' HTTP response header honors charset

### DIFF
--- a/ambariclient/client.py
+++ b/ambariclient/client.py
@@ -161,11 +161,11 @@ class HttpClient(object):
         # there is no consistent way to determine response type
         # so assume json if it's not an empty string
         if len(response.text) > 0:
-            if response.headers.get('content-type') == 'application/x-ustar':
+            if 'application/x-ustar' in response.headers.get('content-type'):
                 tarstream = io.BytesIO(response.content)
                 tarstream.seek(0)
                 return tarfile.open(fileobj=tarstream)
-            elif response.headers.get('content-type') != 'application/json':
+            elif 'application/json' not in response.headers.get('content-type'):
                 # Log bad methods so we can report them
                 LOG.debug("Wrong response content-type for %s %s: %s", method,
                           url, response.headers.get('content-type'))


### PR DESCRIPTION
As noted in HDP 3.1.0.0 , content-type headers also include charset (e.g. application/x-ustar;charset=utf-8) and client needs to honor parsing of that charset to determine right content-type. Without this parsing, can end up with error as below:

>>> ambari = Ambari(server_url, username='admin', password='admin')
>>> ambari.clusters('cluster').services('HBASE').components.get_client_config_tar()
http://node-1.cluster:8080/api/v1/clusters/cluster/services/HBASE/components
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/tests/tmp/ambari-client/python-ambariclient/ambariclient/models.py", line 234, in get_client_config_tar
    return self.client.get(url)
  File "/root/tests/tmp/ambari-client/python-ambariclient/ambariclient/client.py", line 172, in request
    return response.json()
  File "/usr/local/lib/python3.6/site-packages/requests/models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
